### PR TITLE
upgrade go to go1.11

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -77,13 +77,12 @@ RUN apt-get -y install git sudo
 #Required to use go get with git source
 RUN apt-get update && apt-get install -y git
 
-ENV GO_VERSION 1.9.4
-ENV GOPATH=/usr/local/go-packages
-ENV GO_ROOT=/usr/local/go
+ENV GO_VERSION 1.11.4
+ENV GOPATH=/home/theia/go
 ENV PATH $PATH:/usr/local/go/bin
 ENV PATH $PATH:${GOPATH}/bin
 
-RUN curl -sS https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -sS https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 RUN go get -u -v github.com/ramya-rao-a/go-outline
 RUN go get -u -v github.com/acroca/go-symbols
 RUN go get -u -v github.com/nsf/gocode

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-
+ 
 #Common deps
 RUN apt-get update && apt-get -y install curl xz-utils
 

--- a/theia-go-docker/Dockerfile
+++ b/theia-go-docker/Dockerfile
@@ -2,8 +2,11 @@ FROM node:8
 ARG version=latest
 RUN apt-get update && \
     apt-get install -y curl
-RUN curl -sS https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV GO_VERSION 1.11.4
+RUN curl -sS https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH $PATH:/usr/local/go/bin
+ENV GOPATH=/home/theia/go
+ENV PATH $PATH:${GOPATH}/bin
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
@@ -36,5 +39,4 @@ RUN go get -u -v github.com/ramya-rao-a/go-outline && \
     go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct
 RUN mkdir -p /home/theia/.go
 RUN echo '{"toolsGopath":"/home/theia/go"}' > /home/theia/.go/go.json
-ENV GOPATH /home/project    
 ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]


### PR DESCRIPTION
Mirror of https://github.com/theia-ide/theia-apps/pull/117, so that we can have CI running correctly.